### PR TITLE
Fix the deployment dump

### DIFF
--- a/roles/osbuild/tasks/main.yml
+++ b/roles/osbuild/tasks/main.yml
@@ -25,9 +25,9 @@
       osbuild_composer_version: {{ osbuild_composer_version }}
       osbuild_composer_ref: {{ osbuild_composer_ref }}
 
-      cockpit_composer_repo: {{ osbuild_composer_repo }}
-      cockpit_composer_version: {{ osbuild_composer_version }}
-      cockpit_composer_ref: {{ osbuild_composer_ref }}
+      cockpit_composer_repo: {{ cockpit_composer_repo }}
+      cockpit_composer_version: {{ cockpit_composer_version }}
+      cockpit_composer_ref: {{ cockpit_composer_ref }}
 
 - name: Set a password for the default user
   user:


### PR DESCRIPTION
The initial debug dump showed the osbuild-composer data for cockpit-composer
and the data was incorrect.

Signed-off-by: Major Hayden <major@redhat.com>