### PR TITLE
Gather fewer facts

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -11,6 +11,7 @@
       changed_when: "'Nothing to do' not in python_reqs.stdout"
 
 - hosts: test_instances
+  gather_facts: no
   vars_files:
     - vars.yml
   roles:

--- a/roles/osbuild/tasks/main.yml
+++ b/roles/osbuild/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Get a subset of ansible facts
+  setup:
+    gather_subset: "!all,hardware,min,network"
+
 - name: Set the directory where repositories are cloned
   set_fact:
     git_repo_dir: "{{ playbook_dir }}/repos"


### PR DESCRIPTION
Ansible is hanging on fact gathering from time to time. Reduce the
amount of facts we retrieve to reduce this occurrence.

Signed-off-by: Major Hayden <major@redhat.com>