### PR TITLE
Disable IPv6 to reduce Ansible hangs

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -8,6 +8,9 @@ sudo dnf -y install ansible
 sudo mkdir -vp /opt/ansible_{local,remote}
 sudo chmod -R 777 /opt/ansible_{local,remote}
 
+# Disable IPv6 to avoid issues in PSI OpenStack.
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+
 # Run deployment.
 echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
 ansible-playbook -i hosts.ini ${EXTRA_VARS:-} playbook.yml


### PR DESCRIPTION
Signed-off-by: Major Hayden <major@redhat.com>