### PR TITLE
Allow osbuild/osbuild-composer to install from dnf

### DIFF
--- a/roles/osbuild/tasks/install.yml
+++ b/roles/osbuild/tasks/install.yml
@@ -64,6 +64,7 @@
     clone: yes
     update: yes
     track_submodules: no
+  when: install_osbuild_from_git
 
 - name: Clone osbuild-composer from GitHub
   git:
@@ -75,6 +76,7 @@
     clone: yes
     update: yes
     track_submodules: no
+  when: install_osbuild_composer_from_git
 
 - name: Clone cockpit-composer from GitHub
   git:
@@ -100,6 +102,8 @@
   until: composer_builddep is success
   retries: 5
   changed_when: "'Nothing to do' in composer_builddep.stdout"
+  when:
+    - install_osbuild_composer_from_git or install_osbuild_from_git
 
 - name: Build RPMs
   command: make -C "{{ item.dir }}" rpm
@@ -108,10 +112,10 @@
   loop:
     - project: osbuild
       dir: "{{ git_repo_dir }}/osbuild"
-      enabled: yes
+      enabled: "{{ install_osbuild_from_git }}"
     - project: osbuild-composer
       dir: "{{ git_repo_dir }}/osbuild-composer"
-      enabled: yes
+      enabled: "{{ install_osbuild_composer_from_git }}"
     - project: cockpit-composer
       dir: "{{ git_repo_dir }}/cockpit-composer"
       enabled: "{{ install_cockpit_composer_from_git }}"
@@ -140,11 +144,13 @@
   command: "find {{ git_repo_dir }}/osbuild/rpmbuild/RPMS/ -name '*.rpm'"
   register: osbuild_packages
   changed_when: false
+  when: install_osbuild_from_git
 
 - name: Get a list of RPMs built for osbuild-composer
   command: "find {{ git_repo_dir }}/osbuild-composer/rpmbuild/RPMS/ -name '*.rpm'"
   register: composer_packages
   changed_when: false
+  when: install_osbuild_composer_from_git
 
 - name: Get a list of RPMs built for cockpit-composer
   command: "find {{ git_repo_dir }}/cockpit-composer/ -name '*.rpm'"
@@ -211,6 +217,20 @@
     warn: no
   become: yes
   changed_when: true
+
+- name: Install osbuild and osbuild-composer from dnf if needed
+  dnf:
+    name:
+      - osbuild
+      - osbuild-ostree
+      - osbuild-composer
+      - osbuild-composer-rcm
+      - osbuild-composer-tests
+      - osbuild-composer-worker
+      - python3-osbuild
+  become: yes
+  when:
+    - not install_osbuild_composer_from_git or not install_osbuild_from_git
 
 - name: Enable services
   service:

--- a/roles/osbuild/tasks/main.yml
+++ b/roles/osbuild/tasks/main.yml
@@ -34,20 +34,28 @@
     msg: |
       Current deployment plan:
 
+      {% if install_osbuild_from_git %}
       osbuild_repo: {{ osbuild_repo }}
       osbuild_version: {{ osbuild_version }}
       osbuild_ref: {{ osbuild_ref }}
+      {% else %}
+      osbuild__version: from existing dnf repository
+      {% endif %}
 
+      {% if install_osbuild_composer_from_git %}
       osbuild_composer_repo: {{ osbuild_composer_repo }}
       osbuild_composer_version: {{ osbuild_composer_version }}
       osbuild_composer_ref: {{ osbuild_composer_ref }}
+      {% else %}
+      osbuild_composer_version: from existing dnf repository
+      {% endif %}
 
       {% if install_cockpit_composer_from_git %}
       cockpit_composer_repo: {{ cockpit_composer_repo }}
       cockpit_composer_version: {{ cockpit_composer_version }}
       cockpit_composer_ref: {{ cockpit_composer_ref }}
       {% else %}
-      cockpit_composer_version: from Fedora's repositories
+      cockpit_composer_version: from existing dnf repository
       {% endif %}
 
 - name: Set a password for the default user

--- a/vars.yml
+++ b/vars.yml
@@ -15,6 +15,12 @@
 # Update all software packages before building and installing.
 update_all_packages: no
 
+# Install osbuild from git.
+install_osbuild_from_git: yes
+
+# Install osbuild-composer from git.
+install_osbuild_composer_from_git: yes
+
 # Install cockpit-composer from git.
 install_cockpit_composer_from_git: no
 


### PR DESCRIPTION
In certain situations, we want to test with osbuild and osbuild-composer
from a dnf repository rather than from git.

Signed-off-by: Major Hayden <major@redhat.com>