### PR TITLE
Fix refspec to include pull requests

### DIFF
--- a/roles/osbuild/tasks/mock_build.yml
+++ b/roles/osbuild/tasks/mock_build.yml
@@ -47,7 +47,7 @@
     repo: "https://github.com/osbuild/{{ item.repo_name }}"
     dest: "{{ git_repos_dir }}/{{ item.repo_name }}"
     version: "{{ item.version }}"
-    refspec: "+refs/pull/*:refs/heads/*"
+    refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
   loop:
     - repo_name: osbuild
       version: "{{ osbuild_version }}"


### PR DESCRIPTION
The refspec for cloning osbuild/osbuild-composer didn't include the pull
request branches from GitHub and that caused errors on clone.

Fixes #52

Signed-off-by: Major Hayden <major@redhat.com>