### PR TITLE
Allow override for repository URL

### DIFF
--- a/roles/osbuild/tasks/mock_build.yml
+++ b/roles/osbuild/tasks/mock_build.yml
@@ -44,14 +44,16 @@
 
 - name: Clone each repository
   git:
-    repo: "https://github.com/osbuild/{{ item.repo_name }}"
+    repo: "{{ item.repo_url }}"
     dest: "{{ git_repos_dir }}/{{ item.repo_name }}"
     version: "{{ item.version }}"
     refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
   loop:
     - repo_name: osbuild
+      repo_url: "{{ osbuild_repo_url }}"
       version: "{{ osbuild_version }}"
     - repo_name: osbuild-composer
+      repo_url: "{{ osbuild_composer_repo_url }}"
       version: "{{ osbuild_composer_version }}"
 
 - name: Build source RPMs

--- a/vars.yml
+++ b/vars.yml
@@ -12,6 +12,10 @@ install_source: mock
 osbuild_version: master
 osbuild_composer_version: master
 
+# Repository URLs (you can override these to use a local clone)
+osbuild_repo_url: https://github.com/osbuild/osbuild.git
+osbuild_composer_repo_url: https://github.com/osbuild/osbuild-composer.git
+
 # Set the default password to match the default username.
 password_hashes:
   "cloud-user": "$6$4NoiMXLSuKgYaQ/2$xlvgej/fnceUXjseJDWYQu1YI0ApaexYCVvs8xOCs6onxTRO7Yj3blD3IB/Axa4imdiFYkJHbg050oOFrGAa30"


### PR DESCRIPTION
Jenkins clones a repository and then merges the PR into it, and this
creates a SHA1 that doesn't exist anywhere else other than Jenkins.
Allow a user to override the repo URL so that repo that Jenkins cloned
can be used.

Signed-off-by: Major Hayden <major@redhat.com>