### PR TITLE
Always preserve mock logs

### DIFF
--- a/roles/osbuild/tasks/mock_build.yml
+++ b/roles/osbuild/tasks/mock_build.yml
@@ -87,37 +87,41 @@
     path: "{{ yum_repo_dir }}"
     state: directory
 
-- name: Build the source RPMs in the mock
-  command: |
-    mock -r {{ mock_config }} --no-bootstrap-chroot \
-      --resultdir {{ yum_repo_dir }}/ --with=tests \
-      {{ source_rpms.files | map(attribute='path') | list | join(' ') }}
-  become: yes
-  register: mock_output
+- block:
 
-- name: Write mock output to log file
-  copy:
-    dest: "{{ workspace }}/mock-output.log"
-    content: |
-      mock stderr:
-      {{ mock_output.stderr }}
+    - name: Build the source RPMs in the mock
+      command: |
+        mock -r {{ mock_config }} --no-bootstrap-chroot \
+          --resultdir {{ yum_repo_dir }}/ --with=tests \
+          {{ source_rpms.files | map(attribute='path') | list | join(' ') }}
+      become: yes
+      register: mock_output
 
-      mock stdout:
-      {{ mock_output.stdout }}
+  always:
 
-- name: Find the mock logs
-  find:
-    paths: "{{ yum_repo_dir }}"
-    patterns: "*.log"
-    recurse: yes
-  register: mock_logs
+    - name: Write mock output to log file
+      copy:
+        dest: "{{ workspace }}/mock-output.log"
+        content: |
+          mock stderr:
+          {{ mock_output.stderr }}
 
-- name: Copy the mock logs to the workspace directory
-  copy:
-    src: "{{ item }}"
-    dest: "{{ workspace }}/mock_log-{{ item | basename }}"
-    remote_src: yes
-  loop: "{{ mock_logs.files | map(attribute='path') | list }}"
+          mock stdout:
+          {{ mock_output.stdout }}
+
+    - name: Find the mock logs
+      find:
+        paths: "{{ yum_repo_dir }}"
+        patterns: "*.log"
+        recurse: yes
+      register: mock_logs
+
+    - name: Copy the mock logs to the workspace directory
+      copy:
+        src: "{{ item }}"
+        dest: "{{ workspace }}/mock_log-{{ item | basename }}"
+        remote_src: yes
+      loop: "{{ mock_logs.files | map(attribute='path') | list }}"
 
 - name: Create a repo from the RPMs
   command: "createrepo_c {{ yum_repo_dir }}"


### PR DESCRIPTION
Ensure that logs are _always_ preserved, even if the mock build fails.

Signed-off-by: Major Hayden <major@redhat.com>