### PR TITLE
Use sudo for dnf list

### DIFF
--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -18,7 +18,7 @@ priority=5
 EOF
 
 # Verify that the repository we added is working properly.
-dnf list all | grep osbuild-mock
+sudo dnf list all | grep osbuild-mock
 
 # Create temporary directories for Ansible.
 sudo mkdir -vp /opt/ansible_{local,remote}


### PR DESCRIPTION
Avoid dnf read-only database errors by using sudo with dnf list.

Signed-off-by: Major Hayden <major@redhat.com>