### PR TITLE
Start osbuild-rcm socket

### DIFF
--- a/roles/osbuild/tasks/post_install.yml
+++ b/roles/osbuild/tasks/post_install.yml
@@ -31,6 +31,14 @@
     - osbuild-composer.service
     - osbuild-remote-worker.socket
 
+- name: Start osbuild-rcm socket
+  systemd:
+    name: osbuild-rcm.socket
+    state: started
+    enabled: yes
+  become: yes
+  when: "'composer' in group_names"
+
 - name: Start osbuild-composer's remote worker socket
   systemd:
     name: osbuild-remote-worker.socket

--- a/schutzbot/composer-smoke-test.yml
+++ b/schutzbot/composer-smoke-test.yml
@@ -48,7 +48,7 @@
       command: composer-cli blueprints depsolve bash
 
     - name: Build the image
-      command: composer-cli compose start bash ext4-filesystem
+      command: composer-cli compose start bash ami
 
     - name: List the composes
       command: composer-cli compose list


### PR DESCRIPTION
This was accidentally removed as part of the remote workers PR. 🤭

Signed-off-by: Major Hayden <major@redhat.com>